### PR TITLE
Add wallarm_rule_false_positive resource and wallarm_rules data source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# v1.8.7 (Unreleased)
+
+## NOTES:
+
+* Added new resource `wallarm_rule_false_positive` for stamp-based false positive suppression. Given a `request_id` from the Wallarm Console, the resource looks up the hit, extracts detected stamps and points, and creates one `disable_stamp` rule per unique (point × stamp) pair. Requires a Global Admin (Extended) API token.
+* Added new data source `wallarm_rules` to list all rules (hints) for a client, with optional filtering by rule type.
+
 # v1.8.6 (Feb 12, 2026)
 
 ## NOTES:

--- a/docs/data-sources/rules.md
+++ b/docs/data-sources/rules.md
@@ -1,0 +1,71 @@
+---
+layout: "wallarm"
+page_title: "Wallarm: wallarm_rules"
+subcategory: "Rule"
+description: |-
+  Get a list of Wallarm rules (hints).
+---
+
+# wallarm_rules
+
+Use this data source to retrieve all rules (hints) configured for a client. Supports optional filtering by rule type. Results are paginated automatically.
+
+A common use case is discovering existing `disable_stamp` rules before adopting them into Terraform state via import blocks (Terraform 1.5+).
+
+## Example Usage
+
+```hcl
+# Retrieve all rules for the authenticated client
+data "wallarm_rules" "all" {}
+
+output "total_rules" {
+  value = length(data.wallarm_rules.all.rules)
+}
+```
+
+```hcl
+# Retrieve only disable_stamp rules (false positive suppressions)
+data "wallarm_rules" "stamp_rules" {
+  types = ["disable_stamp"]
+}
+
+output "stamp_rules" {
+  value = data.wallarm_rules.stamp_rules.rules
+}
+```
+
+```hcl
+# Use with jsondecode() to inspect rule points
+data "wallarm_rules" "stamps" {
+  types = ["disable_stamp"]
+}
+
+output "stamp_points" {
+  value = [for r in data.wallarm_rules.stamps.rules : jsondecode(r.point)]
+}
+```
+
+## Argument Reference
+
+* `client_id` - (optional) ID of the client to retrieve rules for. The value is required for [multi-tenant scenarios][1]. Defaults to the client associated with the API token.
+* `types` - (optional) List of rule types to filter by. If omitted, all rule types are returned. Common values: `disable_stamp`, `vpatch`, `regex`, `disable_attack_type`, `rule_mode`, `masking`, `parser_state`.
+
+## Attributes Reference
+
+`rules` - List of rule objects. Each object contains:
+
+* `rule_id` - ID of the rule (hint).
+* `action_id` - ID of the action (the set of matching conditions the rule is attached to).
+* `client_id` - Client ID the rule belongs to.
+* `type` - Rule type string (e.g. `disable_stamp`, `vpatch`).
+* `enabled` - Whether the rule is currently enabled.
+* `mode` - Rule mode, if applicable (e.g. `monitoring`, `block`).
+* `regex` - Regular expression string, for regex-based rule types.
+* `attack_type` - Attack type the rule targets, if applicable.
+* `name` - Rule name, if set.
+* `point` - JSON-encoded string of the request point the rule applies to. Use `jsondecode(rule.point)` in Terraform to work with it as a list.
+* `action` - JSON-encoded string of the rule's matching conditions (action details). Use `jsondecode(rule.action)` to inspect individual conditions.
+* `create_time` - Unix timestamp when the rule was created.
+* `updated_at` - Unix timestamp when the rule was last updated.
+
+[1]: https://docs.wallarm.com/installation/multi-tenant/overview/

--- a/docs/resources/rule_false_positive.md
+++ b/docs/resources/rule_false_positive.md
@@ -1,0 +1,71 @@
+---
+layout: "wallarm"
+page_title: "Wallarm: wallarm_rule_false_positive"
+subcategory: "Rule"
+description: |-
+  Provides the "False positive suppression" rule resource.
+---
+
+# wallarm_rule_false_positive
+
+Provides a resource to suppress false-positive detections using Wallarm's stamp-based mechanism. Given a `request_id` observed in the Wallarm Console, the resource:
+
+1. Looks up the hit via the Wallarm API.
+2. Extracts the detected attack stamps and request point(s).
+3. Creates one `disable_stamp` rule per unique **(point × stamp)** combination, scoped to the same domain and URI path as the original request.
+
+This is a fully Terraform-managed alternative to clicking "Mark as false positive" in the Console, and produces rules that are visible under **Rules → Disable specific attack stamp** in the UI.
+
+**Important:** This resource requires an API token with **Global Admin (Extended)** permissions. Standard Admin tokens do not have permission to create `disable_stamp` rules.
+
+**Supported attack types:** `sqli`, `nosqli`, `rce`, `ssi`, `ssti`, `ldapi`, `mail_injection`, `ssrf`, `ptrav`, `xxe`, `scanner`, `xss`, `redir`, `crlf`. Requests with other detection types (e.g. `blocked_source`, `bot`) will produce an error.
+
+**Important:** Rules made with Terraform can't be altered by other rules that usually change how rules work (middleware, variative_values, variative_by_regex).
+This is because Terraform is designed to keep its configurations stable and not meant to be modified from outside its environment.
+
+## Example Usage
+
+```hcl
+# Suppress a single false-positive XSS detection
+resource "wallarm_rule_false_positive" "xss_fp" {
+  request_id = "0c34fdea81f746a7ab5d765a4fc4fa3e"
+  days_back  = 30
+}
+
+output "created_rules" {
+  value = wallarm_rule_false_positive.xss_fp.created_rules
+}
+```
+
+```hcl
+# Multi-tenant: specify the client explicitly
+resource "wallarm_rule_false_positive" "sqli_fp" {
+  client_id  = 12345
+  request_id = "690b88b3d6664ecb2281b34452567a46"
+  days_back  = 100
+}
+```
+
+## Argument Reference
+
+* `client_id` - (optional) ID of the client to apply the rules to. The value is required for [multi-tenant scenarios][1]. Defaults to the client associated with the API token.
+* `request_id` - (**required**, ForceNew) The request ID (hit ID) as shown in the Wallarm Console. This is the 32-character hexadecimal identifier visible in the Events view. Changing this value destroys and recreates the resource.
+* `days_back` - (optional, ForceNew) How many days back to search for the hit. Defaults to `89`. Must be between `1` and `365`. Increase this value for older events. Changing this value destroys and recreates the resource.
+
+## Attributes Reference
+
+* `attack_id` - The Wallarm internal attack ID that the hit belongs to.
+* `attack_type` - The detected attack type (e.g. `xss`, `sqli`).
+* `domain` - The HTTP `Host` header value of the original request (used to scope the created rules).
+* `path` - The URI path of the original request (used to scope the created rules).
+* `created_rules` - List of `disable_stamp` rules created by this resource. Each element contains:
+  * `rule_id` - ID of the created hint rule.
+  * `action_id` - ID of the action (matching conditions) shared by rules with the same scope.
+  * `stamp` - The attack stamp value that is suppressed.
+  * `point` - JSON-encoded request point where suppression applies (e.g. `["get","myquery"]`).
+
+## Notes on Multiple Rules
+
+A single HTTP request may trigger detection at multiple request points (e.g. two different POST body parameters), or a single point may match multiple stamps. The resource creates one `disable_stamp` rule for every unique **(point, stamp)** pair found in the hit, so `length(created_rules)` may be greater than 1. All rules share the same `action_id` when their domain and path scope is identical.
+
+[1]: https://docs.wallarm.com/installation/multi-tenant/overview/

--- a/examples/data_wallarm_rules.tf
+++ b/examples/data_wallarm_rules.tf
@@ -1,0 +1,3 @@
+data "wallarm_rules" "stamps" {
+  types = ["disable_stamp"]
+}

--- a/examples/wallarm_rule_false_positive.tf
+++ b/examples/wallarm_rule_false_positive.tf
@@ -1,0 +1,4 @@
+resource "wallarm_rule_false_positive" "xss_fp" {
+  request_id = "0c34fdea81f746a7ab5d765a4fc4fa3e"
+  days_back  = 30
+}

--- a/wallarm/config.go
+++ b/wallarm/config.go
@@ -2,6 +2,7 @@ package wallarm
 
 import (
 	"log"
+	"net/http"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/wallarm/wallarm-go"
@@ -17,6 +18,15 @@ var (
 	// ClientID of the Provider User communicating with
 	// the Wallarm Cloud
 	ClientID int
+
+	// APIURL is the base URL of the Wallarm API (set during provider configuration).
+	APIURL string
+
+	// APIHeaders contains the authentication headers for direct HTTP calls.
+	APIHeaders http.Header
+
+	// HTTPClient is the HTTP client used for direct API calls.
+	HTTPClient *http.Client
 )
 
 // Config specifies client related parameters used within calls.

--- a/wallarm/data_source_rules.go
+++ b/wallarm/data_source_rules.go
@@ -1,0 +1,171 @@
+package wallarm
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/wallarm/wallarm-go"
+)
+
+func dataSourceWallarmRules() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceWallarmRulesRead,
+		Schema: map[string]*schema.Schema{
+			"client_id": defaultClientIDWithValidationSchema,
+			"types": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"rules": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"rule_id": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"action_id": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"client_id": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"enabled": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"mode": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"regex": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"attack_type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"point": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"action": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"create_time": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"updated_at": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceWallarmRulesRead(d *schema.ResourceData, m interface{}) error {
+	client := m.(wallarm.API)
+	clientID := retrieveClientID(d)
+
+	var typeFilter []string
+	if v, ok := d.GetOk("types"); ok {
+		for _, t := range v.([]interface{}) {
+			typeFilter = append(typeFilter, t.(string))
+		}
+	}
+
+	var allRules []wallarm.ActionBody
+	const limit = 1000
+	offset := 0
+
+	for {
+		filter := &wallarm.HintFilter{
+			Clientid: []int{clientID},
+		}
+		if len(typeFilter) > 0 {
+			filter.Type = typeFilter
+		}
+
+		resp, err := client.HintRead(&wallarm.HintRead{
+			Filter:    filter,
+			OrderBy:   "updated_at",
+			OrderDesc: true,
+			Limit:     limit,
+			Offset:    offset,
+		})
+		if err != nil {
+			return fmt.Errorf("error reading rules: %w", err)
+		}
+
+		if resp == nil || resp.Body == nil || len(*resp.Body) == 0 {
+			break
+		}
+
+		allRules = append(allRules, *resp.Body...)
+
+		if len(*resp.Body) < limit {
+			break
+		}
+		offset += limit
+	}
+
+	rules := make([]interface{}, 0, len(allRules))
+	for _, rule := range allRules {
+		pointJSON := ""
+		if len(rule.Point) > 0 {
+			if b, err := json.Marshal(rule.Point); err == nil {
+				pointJSON = string(b)
+			}
+		}
+
+		actionJSON := ""
+		if len(rule.Action) > 0 {
+			if b, err := json.Marshal(rule.Action); err == nil {
+				actionJSON = string(b)
+			}
+		}
+
+		rules = append(rules, map[string]interface{}{
+			"rule_id":     rule.ID,
+			"action_id":   rule.ActionID,
+			"client_id":   rule.Clientid,
+			"type":        rule.Type,
+			"enabled":     rule.Enabled,
+			"mode":        rule.Mode,
+			"regex":       rule.Regex,
+			"attack_type": rule.AttackType,
+			"name":        rule.Name,
+			"point":       pointJSON,
+			"action":      actionJSON,
+			"create_time": rule.CreateTime,
+			"updated_at":  rule.UpdatedAt,
+		})
+	}
+
+	if err := d.Set("rules", rules); err != nil {
+		return fmt.Errorf("error setting rules: %w", err)
+	}
+
+	d.SetId(fmt.Sprintf("Rules_%s", time.Now().UTC().String()))
+	return nil
+}

--- a/wallarm/provider.go
+++ b/wallarm/provider.go
@@ -106,6 +106,7 @@ func Provider() terraform.ResourceProvider {
 		DataSourcesMap: map[string]*schema.Resource{
 			"wallarm_node":            dataSourceWallarmNode(),
 			"wallarm_security_issues": dataSourceWallarmSecurityIssues(),
+			"wallarm_rules":           dataSourceWallarmRules(),
 		},
 
 		ResourcesMap: map[string]*schema.Resource{
@@ -160,6 +161,7 @@ func Provider() terraform.ResourceProvider {
 			"wallarm_rule_forced_browsing":           resourceWallarmForcedBrowsing(),
 			"wallarm_rule_graphql_detection":         resourceWallarmGraphqlDetection(),
 			"wallarm_rule_file_upload_size_limit":    resourceWallarmFileUploadSizeLimit(),
+			"wallarm_rule_false_positive":            resourceWallarmFalsePositive(),
 		},
 	}
 
@@ -206,11 +208,17 @@ func providerConfigure(d *schema.ResourceData, terraformVersion string) (interfa
 		}
 	}
 
+	resolvedAPIURL := apiURL
 	if v, ok := d.GetOk("api_host"); ok {
+		resolvedAPIURL = v.(string)
 		options = append(options, wallarm.UsingBaseURL(v.(string)))
 	}
 	options = append(options, wallarm.Headers(authHeaders))
 	config.Options = options
+
+	APIURL = resolvedAPIURL
+	APIHeaders = authHeaders.Clone()
+	HTTPClient = c
 
 	client, err := config.Client()
 	if err != nil {

--- a/wallarm/resource_rule_false_positive.go
+++ b/wallarm/resource_rule_false_positive.go
@@ -1,0 +1,350 @@
+package wallarm
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+	"github.com/wallarm/wallarm-go"
+)
+
+var allowedAttackTypes = map[string]bool{
+	"sqli":           true,
+	"nosqli":         true,
+	"rce":            true,
+	"ssi":            true,
+	"ssti":           true,
+	"ldapi":          true,
+	"mail_injection": true,
+	"ssrf":           true,
+	"ptrav":          true,
+	"xxe":            true,
+	"scanner":        true,
+	"xss":            true,
+	"redir":          true,
+	"crlf":           true,
+}
+
+func resourceWallarmFalsePositive() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceWallarmFalsePositiveCreate,
+		Read:   resourceWallarmFalsePositiveRead,
+		Delete: resourceWallarmFalsePositiveDelete,
+		Schema: map[string]*schema.Schema{
+			"client_id": defaultClientIDWithValidationSchema,
+			"request_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"days_back": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				Default:      89,
+				ForceNew:     true,
+				ValidateFunc: validation.IntBetween(1, 365),
+				Description:  "How many days back to search for the request (default 89). Limits the time window of the hit query.",
+			},
+			"attack_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"attack_type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"domain": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"path": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"created_rules": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"rule_id": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"action_id": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"stamp": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"point": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+// hitAPIResponse is the row-based response from /v1/objects/hit.
+type hitAPIResponse struct {
+	Status int       `json:"status"`
+	Body   []hitBody `json:"body"`
+}
+
+// hitBody represents a single hit returned by the API.
+type hitBody struct {
+	Type      string        `json:"type"`
+	Stamps    []int         `json:"stamps"`
+	Point     []interface{} `json:"point"`
+	Domain    string        `json:"domain"`
+	Path      string        `json:"path"`
+	AttackID  []string      `json:"attackid"`
+	RequestID string        `json:"request_id"`
+}
+
+func resourceWallarmFalsePositiveCreate(d *schema.ResourceData, m interface{}) error {
+	client := m.(wallarm.API)
+	clientID := retrieveClientID(d)
+	requestID := d.Get("request_id").(string)
+	daysBack := d.Get("days_back").(int)
+
+	// Compute time window for the hit search.
+	now := time.Now().UTC()
+	startOfWindow := now.AddDate(0, 0, -daysBack).Truncate(24 * time.Hour)
+	endOfWindow := time.Date(now.Year(), now.Month(), now.Day(), 23, 59, 59, 0, time.UTC)
+	start := int(startOfWindow.Unix())
+	end := int(endOfWindow.Unix())
+
+	// 1. Look up the hit(s) matching this request_id.
+	hitReqBody := map[string]interface{}{
+		"filter": map[string]interface{}{
+			"clientid":   []int{clientID},
+			"request_id": []string{requestID},
+			"time":       [][]int{{start, end}},
+		},
+		"limit": 100,
+	}
+
+	hitRespBytes, err := doAPIPost(APIURL+"/v1/objects/hit", hitReqBody)
+	if err != nil {
+		return fmt.Errorf("error looking up hit for request_id %q: %w", requestID, err)
+	}
+
+	var hitResp hitAPIResponse
+	if err := json.Unmarshal(hitRespBytes, &hitResp); err != nil {
+		return fmt.Errorf("error parsing hit response: %w", err)
+	}
+
+	if len(hitResp.Body) == 0 {
+		return fmt.Errorf("no hit found for request_id %q in the last %d days", requestID, daysBack)
+	}
+
+	// Use the first hit for metadata. All hits sharing a request_id come from the same request.
+	firstHit := hitResp.Body[0]
+	attackType := firstHit.Type
+	domain := firstHit.Domain
+	attackPath := firstHit.Path
+
+	// 2. Validate the attack type supports false-positive suppression via disable_stamp.
+	if !allowedAttackTypes[attackType] {
+		return fmt.Errorf("attack type %q is not supported for false positive suppression (must be one of: sqli, nosqli, rce, ssi, ssti, ldapi, mail_injection, ssrf, ptrav, xxe, scanner, xss, redir, crlf)", attackType)
+	}
+
+	// Format the attackid from the compound array.
+	attackID := ""
+	if len(firstHit.AttackID) >= 2 {
+		attackID = firstHit.AttackID[0] + ":" + firstHit.AttackID[1]
+	}
+
+	d.Set("attack_id", attackID)     //nolint:errcheck
+	d.Set("attack_type", attackType) //nolint:errcheck
+	d.Set("domain", domain)          //nolint:errcheck
+	d.Set("path", attackPath)        //nolint:errcheck
+
+	// 3. Collect unique (pointJSON, stamp) pairs across all hits for this request.
+	// map[pointJSON]map[stamp]bool
+	uniquePairs := make(map[string]map[int]bool)
+
+	for _, hit := range hitResp.Body {
+		if len(hit.Point) == 0 || len(hit.Stamps) == 0 {
+			continue
+		}
+
+		pointJSON, err := json.Marshal(hit.Point)
+		if err != nil {
+			log.Printf("[WARN] wallarm_rule_false_positive: could not marshal point %v: %v", hit.Point, err)
+			continue
+		}
+		pointKey := string(pointJSON)
+
+		if uniquePairs[pointKey] == nil {
+			uniquePairs[pointKey] = make(map[int]bool)
+		}
+		for _, stamp := range hit.Stamps {
+			uniquePairs[pointKey][stamp] = true
+		}
+	}
+
+	if len(uniquePairs) == 0 {
+		return fmt.Errorf("hit for request_id %q has no stamps — cannot create disable_stamp rules (attack type may not use stamp-based detection)", requestID)
+	}
+
+	// 4. Create one disable_stamp hint per unique (point, stamp) pair.
+	var createdRules []interface{}
+
+	for pointKey, stamps := range uniquePairs {
+		var pointElems []interface{}
+		if err := json.Unmarshal([]byte(pointKey), &pointElems); err != nil {
+			return fmt.Errorf("error unmarshalling point %q: %w", pointKey, err)
+		}
+
+		for stamp := range stamps {
+			wm := &wallarm.ActionCreate{
+				Type:     "disable_stamp",
+				Clientid: clientID,
+				Stamp:    stamp,
+				Point:    wallarm.TwoDimensionalSlice{pointElems},
+				Action: &[]wallarm.ActionDetails{
+					{Type: "equal", Point: []interface{}{"header", "HOST"}, Value: domain},
+					{Type: "iequal", Point: []interface{}{"uri"}, Value: attackPath},
+				},
+				Comment:             "Managed by Terraform (false positive suppression)",
+				Validated:           false,
+				VariativityDisabled: true,
+			}
+
+			actionResp, err := client.HintCreate(wm)
+			if err != nil {
+				return fmt.Errorf("error creating disable_stamp rule for stamp %d, point %q: %w", stamp, pointKey, err)
+			}
+
+			createdRules = append(createdRules, map[string]interface{}{
+				"rule_id":   actionResp.Body.ID,
+				"action_id": actionResp.Body.ActionID,
+				"stamp":     stamp,
+				"point":     pointKey,
+			})
+		}
+	}
+
+	if err := d.Set("created_rules", createdRules); err != nil {
+		return fmt.Errorf("error setting created_rules: %w", err)
+	}
+
+	d.SetId(fmt.Sprintf("%d/%s", clientID, requestID))
+
+	return resourceWallarmFalsePositiveRead(d, m)
+}
+
+func resourceWallarmFalsePositiveRead(d *schema.ResourceData, m interface{}) error {
+	client := m.(wallarm.API)
+	clientID := retrieveClientID(d)
+
+	rawRules, ok := d.GetOk("created_rules")
+	if !ok {
+		return nil
+	}
+
+	var existingRules []interface{}
+
+	for _, rawRule := range rawRules.([]interface{}) {
+		rule := rawRule.(map[string]interface{})
+		ruleID := rule["rule_id"].(int)
+
+		_, err := findRule(client, clientID, ruleID)
+		if err != nil {
+			if _, notFound := err.(*ruleNotFoundError); notFound {
+				log.Printf("[WARN] wallarm_rule_false_positive: rule %d not found, removing from state", ruleID)
+				continue
+			}
+			return err
+		}
+		existingRules = append(existingRules, rule)
+	}
+
+	if len(existingRules) == 0 {
+		d.SetId("")
+		return nil
+	}
+
+	return d.Set("created_rules", existingRules)
+}
+
+func resourceWallarmFalsePositiveDelete(d *schema.ResourceData, m interface{}) error {
+	client := m.(wallarm.API)
+	clientID := retrieveClientID(d)
+
+	rawRules, ok := d.GetOk("created_rules")
+	if !ok {
+		return nil
+	}
+
+	for _, rawRule := range rawRules.([]interface{}) {
+		rule := rawRule.(map[string]interface{})
+		ruleID := rule["rule_id"].(int)
+
+		h := &wallarm.HintDelete{
+			Filter: &wallarm.HintDeleteFilter{
+				Clientid: []int{clientID},
+				ID:       ruleID,
+			},
+		}
+
+		if err := client.HintDelete(h); err != nil {
+			notFound, _ := isNotFoundError(err)
+			if !notFound {
+				return fmt.Errorf("error deleting disable_stamp rule %d: %w", ruleID, err)
+			}
+			log.Printf("[WARN] wallarm_rule_false_positive: rule %d already deleted", ruleID)
+		}
+	}
+
+	return nil
+}
+
+// doAPIPost makes an authenticated POST request using the package-level HTTPClient and APIHeaders.
+func doAPIPost(url string, body interface{}) ([]byte, error) {
+	data, err := json.Marshal(body)
+	if err != nil {
+		return nil, fmt.Errorf("error marshalling request body: %w", err)
+	}
+
+	req, err := http.NewRequest("POST", url, bytes.NewReader(data))
+	if err != nil {
+		return nil, fmt.Errorf("error creating HTTP request to %s: %w", url, err)
+	}
+
+	for key, values := range APIHeaders {
+		for _, value := range values {
+			req.Header.Add(key, value)
+		}
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := HTTPClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("error executing HTTP request to %s: %w", url, err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("error reading response body from %s: %w", url, err)
+	}
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("HTTP %d from %s: %s", resp.StatusCode, url, string(respBody))
+	}
+
+	return respBody, nil
+}


### PR DESCRIPTION
## Summary

- Add `wallarm_rule_false_positive` resource: given a `request_id` from the Wallarm Console, looks up the hit via the Wallarm API, extracts detected attack stamps and request points, and creates one `disable_stamp` rule per unique (point × stamp) pair. Requires a Global Admin (Extended) API token.
- Add `wallarm_rules` data source: lists all rules (hints) for a client with optional filtering by rule type, using automatic pagination.

## Changes

- `wallarm/config.go` — added package-level `APIURL`, `APIHeaders`, `HTTPClient` vars for direct HTTP access from the false positive resource
- `wallarm/provider.go` — populate those vars in `providerConfigure()`, register both new objects
- `wallarm/resource_rule_false_positive.go` — new resource implementation
- `wallarm/data_source_rules.go` — new data source implementation
- `docs/resources/rule_false_positive.md` — resource documentation
- `docs/data-sources/rules.md` — data source documentation
- `examples/wallarm_rule_false_positive.tf` and `examples/data_wallarm_rules.tf` — usage examples
- `CHANGELOG.md` — unreleased v1.8.7 notes

## Test plan

- [x] `make build` passes
- [x] `make vet` passes
- [x] `make lint` passes
- [x] Live apply/destroy cycle with a real XSS hit (single stamp, single point) — 1 rule created
- [x] Live apply with a deep nested GraphQL/JSON SQLi point (17-element point array including integer index) — rule created correctly
- [x] Live apply with a NoSQLi hit carrying 2 stamps at one point — 2 rules created with shared `action_id`
- [x] Unsupported attack type (`blocked_source`) returns a descriptive error before making any API write calls
- [x] `terraform plan` after apply shows no drift (idempotent read)
- [x] `terraform destroy` removes all created rules

🤖 Generated with [Claude Code](https://claude.com/claude-code)