### PR TITLE
Adopt resource references to doc framework

### DIFF
--- a/references/api-specs.md
+++ b/references/api-specs.md
@@ -1,6 +1,74 @@
-# API Specifications
+# API specs
 
-## Resources
+Reference for `wallarm_api_spec` and `wallarm_api_spec_policy`: the upload/scope
+model and the per-violation policy. Full field lists are the registry docs
+(`docs/resources/api_spec.md`, `docs/resources/api_spec_policy.md`).
 
-- `wallarm_api_spec` — API specification upload + scope. URL-only (`file_remote_url`); file-upload mode pending.
-- `wallarm_api_spec_policy` — per-violation block/monitor/ignore policy attached to an uploaded spec.
+## 1. Overview
+
+`wallarm_api_spec` registers an API specification (OpenAPI/Swagger) with Wallarm
+and scopes it to domains; Wallarm detects endpoints from it. `wallarm_api_spec_policy`
+attaches a per-violation policy (block / monitor / ignore) to an uploaded spec.
+
+## 2. Model
+
+```mermaid
+flowchart LR
+  U["wallarm_api_spec<br/>(file_remote_url + domains)"] --> D["detected endpoints"]
+  P["wallarm_api_spec_policy"] -->|per violation type| U
+```
+
+The spec resource owns the uploaded document and its scope; the policy resource
+references a spec and sets how each violation type is handled.
+
+## 3. Elements
+
+| Element | Role |
+|---|---|
+| `wallarm_api_spec` | spec upload + scope; tracks the source document |
+| `wallarm_api_spec_policy` | per-violation block/monitor/ignore policy for a spec |
+| wallarm-go `APISpec*` | client calls; `APISpecReadByID` for per-ID reads |
+
+## 4. Behavior
+
+- **URL-only ingestion.** The spec is provided via `file_remote_url`; direct
+  file upload (multipart) is not yet supported (roadmap **AS1**) - host the spec
+  at a URL or manage it via the console + import.
+- **Drift tracking.** `file_changed_at` and the nested `file.checksum` (inside
+  the computed `file` block) track the source document; `api_detection` toggles
+  endpoint detection.
+- **Policy.** `wallarm_api_spec_policy` sets the action per violation type
+  against a referenced spec.
+- **Pagination.** wallarm-go `APISpecList` is single-page (caller iterates); an
+  auto-paginating `APISpecListAll` is deferred until a consumer exists (roadmap
+  **AS2**).
+
+## 5. Parameters
+
+`wallarm_api_spec` (key fields; full list in the registry doc):
+
+| Field | Kind | Notes |
+|---|---|---|
+| `file_remote_url` | input | URL of the spec document |
+| `domains` | input | domains the spec scopes to |
+| `description` | input | free-text label |
+| `auth_headers` | input | headers used to fetch/authenticate |
+| `api_detection` | input | endpoint-detection toggle |
+| `api_spec_id` | computed | spec ID |
+| `file_changed_at` / `created_at` | computed | source-tracking timestamps |
+| `file` block (incl. `file.checksum`) | computed | uploaded-document metadata |
+| `endpoints_count` | computed | detected endpoints |
+
+`wallarm_api_spec_policy` references a spec and sets per-violation actions
+(`block` / `monitor` / `ignore`); see the registry doc for the violation list.
+
+## 6. Reference data
+
+- `file_remote_url` is the only ingestion mode today (AS1 tracks file upload).
+- `APISpecList(clientID, page, perPage)` is single-page (AS2 tracks
+  `APISpecListAll`).
+
+## 7. References
+
+- Roadmap `AS1` (file-upload mode), `AS2` (auto-paginating list).
+- `docs/resources/api_spec.md`, `docs/resources/api_spec_policy.md`.

--- a/references/infrastructure.md
+++ b/references/infrastructure.md
@@ -1,13 +1,80 @@
-# Other Infrastructure Resources
+# Infrastructure resources
 
-## Tenant (`wallarm_tenant`)
+Reference for the account- and node-level resources that are not rules:
+`wallarm_tenant`, `wallarm_node`, `wallarm_user`, `wallarm_application`,
+`wallarm_global_mode`. Full field lists are the registry docs
+(`docs/resources/*.md`); this doc is the shared model and the delete/Read
+gotchas.
 
-Delete safety: disables first, only permanently deletes if `prevent_destroy=false` AND `WALLARM_ALLOW_CLIENT_DELETE=1`.
+## 1. Overview
 
-## Node (`wallarm_node`)
+These resources manage the account itself rather than traffic rules:
+multi-tenancy (`tenant`), filtering nodes (`node`), user accounts (`user`), the
+application/pool registry (`application`), and the account-wide filtration mode
+(`global_mode`).
 
-Default application (`app_id=-1`) is protected from deletion.
+## 2. Model
 
-## User (`wallarm_user`)
+| Resource | Manages |
+|---|---|
+| `wallarm_tenant` | a tenant (client) account under a partner account |
+| `wallarm_node` | a filtering node, and its default application |
+| `wallarm_user` | a user account within a client |
+| `wallarm_application` | an application/pool (`app_id`) other resources scope to |
+| `wallarm_global_mode` | account-wide filtration + rechecker + overlimit settings |
 
-User accounts are created with `username` (which equals `email` per the domain model).
+## 3. Elements
+
+Each resource wraps the matching wallarm-go client calls. `application` is the
+scoping unit referenced by rules and IP lists via `app_id`; `global_mode` is a
+singleton-style account setting.
+
+## 4. Behavior
+
+- **`wallarm_tenant` delete safety.** Delete disables the tenant first, and
+  permanently deletes only when `prevent_destroy = false` **and**
+  `WALLARM_ALLOW_CLIENT_DELETE` is set (`resource_tenant.go:211-218`); otherwise
+  it logs a warning and no-ops, leaving the tenant disabled but not deleted.
+- **`wallarm_node`.** `partner_mode` is `Optional+Computed` and **not set by
+  Read**, so out-of-band toggles are not drift-detected (roadmap **INF2**). The
+  node schema has no `app_id` field.
+- **`wallarm_user`.** Accounts are created with `username`, which equals `email`
+  per the domain model. `email` is `Required` but **not set by Read**, so after
+  import the user must re-add `email = "..."` by hand (roadmap **INF1**; Read
+  could mirror `email = username`).
+- **`wallarm_application`.** Carries `app_id`, `client_id`, `name`; the default
+  application (`app_id = -1`) is protected from deletion
+  (`resource_application.go:146-149`).
+- **`wallarm_global_mode`.** Sets `filtration_mode`, `rechecker_mode`,
+  `overlimit_time`, `overlimit_mode` for the account (§6).
+
+## 5. Parameters
+
+Key fields (full shapes in the registry docs):
+
+| Resource | Fields |
+|---|---|
+| `wallarm_tenant` | `name`, `prevent_destroy`, computed client id |
+| `wallarm_node` | `hostname`, `node_uuid`, `token`, `partner_mode` (no `app_id`) |
+| `wallarm_user` | `email` (== `username`), role, `client_id` |
+| `wallarm_application` | `app_id` (`-1` = protected default), `client_id`, `name` |
+| `wallarm_global_mode` | `filtration_mode`, `rechecker_mode`, `overlimit_time`, `overlimit_mode`, `client_id` |
+
+## 6. Reference data
+
+`wallarm_global_mode` enums (`resource_global_mode.go`):
+
+| Field | Values |
+|---|---|
+| `filtration_mode` | `default` / `monitoring` / `block` / `safe_blocking` / `off` |
+| `rechecker_mode` | `on` / `off` |
+| `overlimit_mode` | `blocking` / `monitoring` |
+
+- `wallarm_tenant`: env `WALLARM_ALLOW_CLIENT_DELETE` (any non-empty value)
+  gates permanent delete.
+- `wallarm_application`: `app_id = -1` (the default application) is undeletable.
+
+## 7. References
+
+- Roadmap `INF1` (`user.email` Read), `INF2` (`node.partner_mode` drift).
+- `docs/resources/{tenant,node,user,application,global_mode}.md` - full fields.

--- a/references/integrations.md
+++ b/references/integrations.md
@@ -1,16 +1,101 @@
 # Integrations
 
-## Eleven integration resources
+Reference for the 11 `wallarm_integration_*` resources: what they share, the
+event-subscription model, and the current Read-completeness limitation. Full
+per-integration field lists are the registry docs
+(`docs/resources/integration_*.md`); this doc is the shared model and machinery.
 
-`wallarm_integration_data_dog`, `_email`, `_insightconnect`, `_opsgenie`, `_pagerduty`, `_slack`, `_splunk`, `_sumologic`, `_teams`, `_telegram`, `_webhook`.
+## 1. Overview
 
-## Read-completeness blocker
+Each integration resource connects Wallarm to an external system (chat, SIEM,
+incident, webhook) and subscribes it to a set of Wallarm events. All 11 share
+one CRUD shape: generic metadata + a transport-specific connection config + an
+`event` subscription set.
 
-All 11 integration Read functions populate only generic metadata (`integration_id`, `is_active`, `name`, `created_by`, `type`, `client_id`). They drop the type-specific fields the API returns: `active` (user-set flag), `event[]` (TypeSet of event subscriptions), and per-integration config (`emails`, `webhook_url`, `api_url`, `api_token`, `headers`, `timeouts`, `chat_data`, `integration_key`, `with_headers`, etc.).
+## 2. Model
 
-Consequences: `terraform import` + `-generate-config-out` produces incomplete HCL (verified with `integration_email`: generated config has `null` for `active`, `emails`, and completely missing all `event {}` blocks vs the real config's 7 event subscriptions). Drift detection is also broken — UI edits to events/active/recipient lists are invisible to plan.
+```mermaid
+erDiagram
+  INTEGRATION ||--o{ EVENT : "subscribes to"
+  INTEGRATION {
+    int    integration_id "computed"
+    string name
+    string type "computed - transport"
+    bool   active "user-set enable flag"
+  }
+  EVENT {
+    string event_type
+    bool   active
+  }
+```
 
-**Fix:** each integration's Read needs:
-1. A flatten helper for the `event[]` TypeSet (reverse of existing `expandWallarmEventToIntEvents`).
-2. `d.Set` calls for every type-specific config field on the API response.
-3. Likely a new typed `IntegrationRead` variant in wallarm-go if the generic one doesn't return full payloads per integration type — investigate first.
+An integration is generic metadata (`integration_id`, `name`, `type`, `active`,
+`created_by`, `client_id`) plus transport-specific connection fields plus an
+`event` TypeSet, expanded to the API by `expandWallarmEventToIntEvents`.
+
+## 3. Elements
+
+| Resource | Transport |
+|---|---|
+| `wallarm_integration_data_dog` | Datadog |
+| `wallarm_integration_email` | email recipients |
+| `wallarm_integration_insightconnect` | Rapid7 InsightConnect |
+| `wallarm_integration_opsgenie` | Opsgenie |
+| `wallarm_integration_pagerduty` | PagerDuty |
+| `wallarm_integration_slack` | Slack webhook |
+| `wallarm_integration_splunk` | Splunk HEC |
+| `wallarm_integration_sumologic` | Sumo Logic |
+| `wallarm_integration_teams` | Microsoft Teams |
+| `wallarm_integration_telegram` | Telegram |
+| `wallarm_integration_webhook` | generic webhook |
+
+`expandWallarmEventToIntEvents` converts the `event` set to the API payload.
+It has no flatten counterpart - the reason Read is incomplete (§4).
+
+## 4. Behavior
+
+- **Create / Update** send the full config (transport fields + `event` set).
+- **Read populates only generic metadata** (`integration_id`, `is_active`,
+  `name`, `created_by`, `type`, `client_id`; e.g.
+  `resource_integration_email.go:139-144`). It does **not** set the user-facing
+  `active` flag, the `event` subscriptions, or any transport-specific config the
+  API returned. Consequences:
+  - `terraform import` + `-generate-config-out` yields incomplete HCL (`active`
+    and transport config `null`, all `event {}` blocks missing).
+  - Drift from console edits to events / config is invisible to plan.
+
+  Known limitation tracked as roadmap **I1**. Import sections were removed from
+  the 11 registry docs to avoid misleading users; they return when I1 lands.
+- **No provider-level cache** backs integration Read yet (roadmap **I2**).
+- The 11 resources duplicate CRUD structure; a shared factory is roadmap **I3**.
+
+## 5. Parameters
+
+Common fields (all integrations):
+
+| Field | Notes |
+|---|---|
+| `integration_id` | computed |
+| `type` | computed - transport identifier |
+| `is_active` | computed - server state |
+| `active` | user-set enable flag |
+| `name` | integration name |
+| `created_by` | computed |
+| `client_id` | optional+computed |
+| `event` | TypeSet of `{event_type, active}` subscriptions |
+
+Transport-specific connection fields (`emails`, `webhook_url`, `api_url`,
+`api_token`, `headers`, `with_headers`, `chat_data`, `integration_key`,
+`timeouts`, ...) vary per resource; see `docs/resources/integration_*.md`.
+
+## 6. Reference data
+
+The `event_type` values and each transport's required connection fields are
+enumerated per resource in the registry docs. Read behavior is uniform across
+all 11 (§4).
+
+## 7. References
+
+- Roadmap `I1` (Read completeness), `I2` (cache), `I3` (factory extraction).
+- `docs/resources/integration_*.md` - full per-integration field lists.
+- `rules-core.md §3.4` - the `ProviderMeta` cache pattern a future I2 would follow.

--- a/references/ip-lists.md
+++ b/references/ip-lists.md
@@ -1,22 +1,87 @@
-# IP Lists
+# IP lists
 
-## Resources (`wallarm_allowlist`, `wallarm_denylist`, `wallarm_graylist`)
+Reference for the `wallarm_allowlist` / `wallarm_denylist` / `wallarm_graylist`
+resources: the config-driven Read, the incremental Update, the provider-level
+cache, and the limits. Full field lists are the registry docs
+(`docs/resources/{allowlist,denylist,graylist}.md`); the cache strategy is the
+`terraform-provider-caching` skill.
 
-IP list resources are the most complex resources in the provider due to API behavior. One rule type per resource, max 1000 subnets.
+## 1. Overview
 
-**IP list Reads are config-driven, not API-driven.** `resourceWallarmIPListRead` (shared by `allowlist`, `denylist`, `graylist`) calls `ipListConfigValues(d)` to read the user's HCL values, looks those up in the cached list, and sets only `address_id` / `entry_count`. Other schema fields (`ip_range`, `country`, `datacenter`, `application`, `proxy_type`, `reason`, `time`, `time_format`) are `ForceNew` config inputs — they're never written by Read and that is correct. IP lists are effectively append-only with per-value IDs, so there's no "authoritative state" to reconcile; the user's config IS the state.
+The three IP list resources add IP/subnet entries to Wallarm's allow, deny, and
+gray lists. Entries carry per-value IDs; Read records the derived IDs and counts
+from a provider-level cache rather than reconciling every descriptive field from
+the API, and Update applies changes in place.
 
-## IP list cache
+## 2. Model
 
-Cache at `ProviderMeta` level with per-rule-type fetching and Create serialization. The `terraform-provider-caching` skill is the canonical reference for cache strategy.
+```mermaid
+flowchart LR
+  HCL["HCL config (ip_range, country, ...)"] -->|ipListConfigValues| L["lookup in ProviderMeta IPListCache"]
+  L --> S["set computed: address_id, entry_count, untracked_count, untracked_ips"]
+```
 
-## API limits
+Each resource manages one list type. Descriptive fields are ordinary inputs
+(not `ForceNew`); Read records the computed outputs, and Update reconciles
+changes (§4).
+
+## 3. Elements
+
+| Element | Role |
+|---|---|
+| `resourceWallarmIPListRead` | shared Read for all three list types |
+| `ipListConfigValues` | reads the user's HCL scope values for cache lookup |
+| `resourceWallarmIPListUpdate` | Update handler (`resource_ip_list.go:273`) |
+| `ipListSubnetDiffUpdate` | incremental add/remove of changed subnets (`:302`) |
+| `IPListCache` (`ProviderMeta`, `config.go:19`) | per-list-type cache with Create serialization |
+
+## 4. Behavior
+
+- **Read is config-driven.** `resourceWallarmIPListRead` calls
+  `ipListConfigValues(d)`, looks the values up in the cache, and sets the
+  computed outputs `address_id`, `entry_count`, `untracked_count`,
+  `untracked_ips` (plus `client_id`). It does not pull the descriptive fields
+  (`ip_range`, `country`, `datacenter`, `application`, `proxy_type`, `reason`,
+  `time`, `time_format`) back from the API - those stay as the user's config.
+- **Update reconciles changes** (no field is `ForceNew`):
+  - an `ip_range`-only change runs an incremental subnet diff
+    (`ipListSubnetDiffUpdate`) that adds/removes only the changed IPs;
+  - a change to metadata (`time_format` / `time` / `reason` / `application`)
+    re-runs Create to rebuild the entry.
+- **Cache** sits on `ProviderMeta`, fetches per list type, serializes Creates,
+  and retries a refresh after Create (`IPListCacheMaxRetries` /
+  `IPListCacheRetryDelay`). See the `terraform-provider-caching` skill.
+- **Counts** validation via the `/access_rules/counts` endpoint is planned
+  (roadmap **IPL1**).
+
+## 5. Parameters
+
+| Field | Kind | Notes |
+|---|---|---|
+| `ip_range` | input | the IP or CIDR; an isolated change diffs incrementally |
+| `country` / `datacenter` / `proxy_type` | input | source classifiers |
+| `application` | input | scope to an app/pool; a change re-creates the entry |
+| `reason` | input | free-text label |
+| `time` / `time_format` | input | expiry |
+| `address_id` | computed | per-value ID from the cache |
+| `entry_count` | computed | entries backing this resource |
+| `untracked_count` / `untracked_ips` | computed | list entries the API returned that this config does not track |
+
+Full shapes per list type are in the registry docs.
+
+## 6. Reference data
 
 `wallarm/provider/constants.go` (authoritative):
 
 | Constant | Value | Purpose |
 |---|---|---|
 | `IPListPageSize` | 1000 | IP list groups per API call |
-| `IPListMaxSubnets` | 1000 | Max subnet values per IP list resource |
-| `IPListCacheMaxRetries` | 3 | Cache refresh retries |
-| `IPListCacheRetryDelay` | 3s | Wait between retries |
+| `IPListMaxSubnets` | 1000 | max subnet values per IP list resource |
+| `IPListCacheMaxRetries` | 3 | cache refresh retries after Create |
+| `IPListCacheRetryDelay` | 3s | wait between retries |
+
+## 7. References
+
+- `terraform-provider-caching` skill - the `IPListCache` strategy.
+- Roadmap `IPL1` - counts API validation.
+- `docs/resources/{allowlist,denylist,graylist}.md` - full field lists.

--- a/references/triggers.md
+++ b/references/triggers.md
@@ -1,13 +1,85 @@
 # Triggers
 
-## Resource (`wallarm_trigger`)
+Reference for the `wallarm_trigger` resource: what it is, how it couples to
+counter rules, and the current Read-completeness limitation. Full field lists
+are the registry doc (`docs/resources/trigger.md`); counter rules are in
+`rules-core.md`.
 
-Bound to counter rules (`wallarm_rule_bruteforce_counter`, `_dirbust_counter`, `_bola_counter`) via `hint_tag` filters. Counters auto-clean ~30 seconds after the last trigger reference is removed.
+## 1. Overview
 
-## Read-completeness blocker
+A `wallarm_trigger` fires an action (notification, block, etc.) when a counter
+rule's threshold is crossed within a window. It is the active half of the
+counter/trigger pair: a counter rule accumulates hits, and the trigger reacts.
 
-`resourceWallarmTriggerRead` (`resource_trigger.go:245-267`) finds the matching trigger in the API response but only calls `d.Set("trigger_id", ...)` and `d.Set("client_id", ...)`. It drops `template_id`, `enabled`, `name`, `comment`, `filters`, `actions`, `threshold` — every other field the API returned.
+## 2. Model
 
-Consequences: (1) `terraform import` leaves state with only two fields — user must still hand-write the full config and risks the next `apply` overwriting live state; (2) drift from UI edits is invisible because Read never looks at those fields; (3) acceptance tests can't use `ImportStateVerify: true`.
+```mermaid
+flowchart LR
+  C["counter rule<br/>(bruteforce/dirbust/bola_counter)"] -->|hint_tag filter| T["wallarm_trigger"]
+  T -->|threshold crossed| A["action (notify / block / ...)"]
+```
 
-Fix requires writing `flattenTriggerFilters`, `flattenTriggerActions`, `flattenTriggerThreshold` helpers (reverse of the existing `expandWallarmTrigger*` functions) and calling `d.Set` for every field. Nontrivial — nested TypeList/TypeSet shapes.
+A trigger binds to one or more counter rules through `hint_tag` filters; when
+its `threshold` is met it runs its `actions`. Removing the last trigger that
+references a counter lets the server auto-clean that counter (~30s later, see
+`rules-core.md §4.4`).
+
+## 3. Elements
+
+| Element | Role |
+|---|---|
+| `wallarm_trigger` | the trigger resource (`resource_trigger.go`) |
+| `expandWallarmTriggerFilter` | HCL `filters` -> API |
+| `expandWallarmTriggerThreshold` | HCL `threshold` -> API |
+| `expandWallarmTriggerAction` | HCL `actions` -> API |
+
+There are no `flatten*` counterparts - the reason Read is incomplete (§4).
+
+## 4. Behavior
+
+- **Create / Update** send the full trigger (`filters`, `actions`, `threshold`,
+  `template_id`, `enabled`, `name`, `comment`).
+- **Read populates only `trigger_id` and `client_id`** (`resourceWallarmTriggerRead`,
+  `resource_trigger.go`): it finds the matching trigger in the API response but
+  never sets `template_id`, `enabled`, `name`, `comment`, `filters`, `actions`,
+  or `threshold`. Consequences:
+  - `terraform import` leaves state with two fields; the user must hand-write the
+    full config, and the next `apply` risks overwriting live state.
+  - Drift from console edits is invisible (Read never inspects those fields).
+  - Acceptance tests cannot use `ImportStateVerify: true`.
+
+  Known limitation tracked as roadmap **T1** (needs `flattenTriggerFilters` /
+  `flattenTriggerActions` / `flattenTriggerThreshold` + `d.Set` for every field).
+- `comment` and `lock_time` carry the same SDKv2 zero-value masking risk as the
+  rule-side fields; addressed alongside T1 as roadmap **T2**.
+- The registry doc's `## Import` section is deferred until T1 lands (**T3**);
+  trigger-complexity reduction is **T4**.
+
+## 5. Parameters
+
+| Field | Notes |
+|---|---|
+| `trigger_id` | computed |
+| `client_id` | optional+computed |
+| `template_id` | trigger template |
+| `name` / `comment` | labels |
+| `enabled` | active flag |
+| `filters` | `hint_tag` (and other) filters binding counters |
+| `threshold` | count + window |
+| `actions` | reaction(s) when the threshold is crossed; each carries a nested `lock_time` (reaction lock duration) |
+
+Full field shapes are in `docs/resources/trigger.md`.
+
+## 6. Reference data
+
+Counters that pair with triggers: `wallarm_rule_bruteforce_counter`,
+`wallarm_rule_dirbust_counter`, `wallarm_rule_bola_counter` (catalog in
+`rules-core.md §3.5`). Counter auto-clean delay: ~30s after the last trigger
+reference is removed.
+
+## 7. References
+
+- Roadmap `T1` (Read completeness), `T2` (`comment`/`lock_time` zero-value),
+  `T3` (import docs), `T4` (complexity).
+- `rules-core.md` - counter rules and the counter/trigger coupling.
+- `docs/resources/trigger.md` - full field lists.

--- a/references/wallarm-go.md
+++ b/references/wallarm-go.md
@@ -1,18 +1,68 @@
-# wallarm-go Client Library
+# wallarm-go client library
 
-The `wallarm-go` library (`../wallarm-go`) is the HTTP client for the Wallarm API.
+Reference for the `wallarm-go` HTTP client module (`../wallarm-go`): the request
+behaviors the provider relies on and the conventions for adding API structs. The
+per-field zero-value contract that drives struct tags is in
+`rules_api_fields.md §4.2`.
 
-## Features
+## 1. Overview
 
-- `APIError` struct with `StatusCode` and `Body` fields
-- Automatic retry: 423 (5s × 12), 5xx (10s × 12), 429 (exponential backoff × 12)
-- Gzip compression on all requests (~19x reduction)
-- All paginated methods set `response.Body.Objects = nil` before each `json.Unmarshal` (prevents slice reuse bugs)
+`wallarm-go` is a separate Go module that wraps the Wallarm HTTP API. The
+provider stores a `wallarm.API` (wrapped in `CachedClient`) on `ProviderMeta`
+and calls it from every CRUD path. Changes to struct field identifiers here are
+breaking for the provider, which pattern-matches on the exposed Go names.
 
-## Naming convention for new API structs
+## 2. Model
 
-Follow Go idiomatic initialism style when adding or editing struct fields in `wallarm-go` — `ID`, `URL`, `HTTP`, `API`, `UUID`, `JSON`, etc., not `Id`/`Url`/`Http`. This matches the `golint`/`revive` "var-naming" rule and the rest of the upstream Go ecosystem. JSON tags keep their snake_case (`json:"http_method"`), only Go identifiers change. Example: `HTTPMethod string `json:"http_method"``. Provider-side code and downstream consumers pattern-match on the exposed Go identifier — renames here are breaking.
+The client sends JSON over HTTP, requests gzip-compressed responses, retries
+transient failures, and returns a typed `APIError` on non-success. Paginated
+methods reset the response slice before each page to avoid reuse bugs.
 
-## Zero-value pointer convention
+## 3. Elements
 
-Fields whose API range includes zero as a valid value (`Rate 0..1000`, `Burst 0..N`, `Delay 0..N`, `OverlimitTime 0..N`) MUST be `*int+omitempty` in the Go struct, NOT `int+omitempty` — Go's `encoding/json` drops a literal zero from `int+omitempty`, so the wire payload would be missing the field and the API rejects with `can't be blank`. Pattern is applied to `ActionCreate.{Rate,Burst,Delay,OverlimitTime}`. `RspStatus` keeps `int` because its valid range starts at 400 — zero is not a legal value, so dropping absent via `omitempty` is correct. New API fields must be analyzed for "is zero a meaningful input" before picking the type.
+| Element | Role |
+|---|---|
+| `wallarm.API` | the client interface the provider consumes |
+| `APIError` | typed error with `StatusCode` and `Body` fields |
+| paginated `*List*` methods | page-at-a-time fetch; reset `response.Body.Objects = nil` per page |
+
+## 4. Behavior
+
+- **Retry** (`MaxRetries = 12`, so up to 13 attempts per request: 1 initial +
+  12 retries): HTTP 423 waits 5s, 5xx waits 10s, 429 uses exponential backoff
+  (1s doubling, capped at 30s).
+- **Gzip responses**: the client sends `Accept-Encoding: gzip` and decompresses
+  gzip responses; request bodies are uncompressed JSON.
+- **Pagination safety**: the paginating methods set `response.Body.Objects = nil`
+  before each `json.Unmarshal`, preventing slice reuse across pages.
+- Integration tests for the retry logic are a planned addition (roadmap **WG1**).
+
+## 5. Parameters
+
+Not applicable - this is a client library, not a resource.
+
+## 6. Reference data
+
+### Naming convention for new structs
+
+Use Go idiomatic initialisms for identifiers (`ID`, `URL`, `HTTP`, `API`,
+`UUID`, `JSON`), not `Id`/`Url`/`Http` - matching the `golint`/`revive`
+`var-naming` rule. JSON tags stay snake_case; only Go identifiers change
+(`HTTPMethod string` with `json:"http_method"`). Renames are breaking for the
+provider and downstream consumers.
+
+### Zero-value pointer convention
+
+A field whose valid API range includes `0` must be `*int` + `omitempty`, not
+`int` + `omitempty`: `encoding/json` drops a literal `0` from `int,omitempty`,
+so the field would be absent on the wire and the API rejects it as
+`can't be blank`. Applied to `ActionCreate.{Rate,Burst,Delay,OverlimitTime}`.
+`RspStatus` stays `int` (range starts at 400; `0` is never valid, so dropping it
+via `omitempty` is correct). Analyze "is `0` a meaningful input?" before picking
+the type. Full per-field classification: `rules_api_fields.md §4.2`.
+
+## 7. References
+
+- `rules_api_fields.md §4.2` - the pointer/int classification per field.
+- Roadmap `WG1` - retry-logic integration tests.
+- `rules-core.md §3.4` - `CachedClient` wrapping on `ProviderMeta`.


### PR DESCRIPTION
## Summary

Batch B of the docs-adoption effort: bring the resources-cluster `references/` docs onto the Diataxis Reference framework (7-section skeleton, detail bar). Docs only, no code changes.

- **Reworked to the framework:** `integrations.md`, `triggers.md`, `ip-lists.md`, `api-specs.md`, `infrastructure.md`, `wallarm-go.md`.
- **Code-bug docs now describe limitations as current behavior + cross-link the roadmap** (fix-prose dropped): `integrations.md` -> `I1`-`I3`, `triggers.md` -> `T1`-`T4`.
- `infrastructure.md` expanded to cover `application` + `global_mode` (was tenant/node/user only).
- `ip-lists.md` corrected: the old note claimed `ForceNew`/append-only, but the resource has a full `Update` (incremental subnet diff for `ip_range`, recreate for metadata) - now documented accurately, including the `untracked_count`/`untracked_ips` outputs.

## Test plan

- Docs only; no runtime behavior change.
- Every doc passed an independent-agent verification gate against the Go source; all flagged errors corrected (ip-lists Update semantics, api_spec `file.checksum` nesting, tenant no-op-on-blocked-delete, wallarm-go retry attempt count and response-only gzip).
- CLAUDE.md S2 index already references these filenames (edited in place, no rename) - no CLAUDE.md change needed.
- CI: standard unit + lint pipeline.